### PR TITLE
Add very simple Atom feed

### DIFF
--- a/feed.php
+++ b/feed.php
@@ -1,0 +1,38 @@
+<?php
+include "credentials.php";
+header("Content-type: application/atom+xml; charset=\"utf-8\"");
+
+$stmt = $conn->prepare("SELECT hlasky.*, t.firstName AS 'teacher_firstName', t.lastName AS 'teacher_lastName', t.id AS 'teacher_id' FROM hlasky JOIN teachers t ON teacherId = t.id ORDER BY hlasky.edited DESC");
+$stmt->execute();
+$hlasky = $stmt->fetchAll();
+
+$feed_updated = null;
+if (sizeof($hlasky) > 0) {
+    $feed_updated = $hlasky[0]['edited'];
+}
+
+// RFC4287 section 3.3
+function toAtomDateConstruct($date_from_db) {
+	return $date_from_db; //TODO
+}
+
+?><?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Hláškovník 2.0</title>
+  <link href="https://hlaskovnik.eu"/>
+  <updated><?php echo(htmlspecialchars($feed_updated)); ?></updated>
+  <author>
+    <name>Greenscreener</name>
+  </author>
+  <id>urn:uuid:3fbed38a-bbdb-4877-adb4-88309f2229d9</id>
+
+  <?php foreach ($hlaska as $hlasky) { ?>
+  <entry>
+    <title><?php echo(htmlspecialchars($hlaska['date'])); ?>: <?php echo(htmlspecialchars($hlaska['teacher_firstName'])); ?> <?php echo(htmlspecialchars($hlaska['teacher_lastName'])); ?></title>
+    <link href="https://hlaskovnik.eu/?id=<?php echo(htmlspecialchars(urlencode((string)$hlaska['id']))); ?>"/>
+    <id>https://hlaskovnik.eu/?id=<?php echo(htmlspecialchars(urlencode((string)$hlaska['id']))); ?></id>
+    <updated><?php echo(htmlspecialchars($hlaska['edited'])); ?></updated>
+    <summary><?php echo(htmlspecialchars($hlaska['content'])); ?></summary>
+  </entry>
+  <?php } ?>
+</feed>

--- a/feed.php
+++ b/feed.php
@@ -20,7 +20,7 @@ function toAtomDateConstruct($date_from_db) {
 <feed xmlns="http://www.w3.org/2005/Atom">
   <title>Hláškovník 2.0</title>
   <link href="https://hlaskovnik.eu"/>
-  <updated><?php echo(htmlspecialchars($feed_updated)); ?></updated>
+  <updated><?php echo(htmlspecialchars(toAtomDateConstruct($feed_updated))); ?></updated>
   <author>
     <name>Greenscreener</name>
   </author>
@@ -31,7 +31,7 @@ function toAtomDateConstruct($date_from_db) {
     <title><?php echo(htmlspecialchars($hlaska['date'])); ?>: <?php echo(htmlspecialchars($hlaska['teacher_firstName'])); ?> <?php echo(htmlspecialchars($hlaska['teacher_lastName'])); ?></title>
     <link href="https://hlaskovnik.eu/?id=<?php echo(htmlspecialchars(urlencode((string)$hlaska['id']))); ?>"/>
     <id>https://hlaskovnik.eu/?id=<?php echo(htmlspecialchars(urlencode((string)$hlaska['id']))); ?></id>
-    <updated><?php echo(htmlspecialchars($hlaska['edited'])); ?></updated>
+    <updated><?php echo(htmlspecialchars(toAtomDateConstruct($hlaska['edited']))); ?></updated>
     <summary><?php echo(htmlspecialchars($hlaska['content'])); ?></summary>
   </entry>
   <?php } ?>

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="/assets/styles/style.css">
     <link rel="icon" href="/assets/img/favicon.ico">
     <link rel="icon" href="/assets/img/logo-256px.png">
+    <link rel="alternate" type="application/atom+xml" href="/feed.php" />
     <script src="https://cdn.jsdelivr.net/npm/js-cookie@2/src/js.cookie.min.js"></script>
     <script type="text/javascript" src="assets/js/hlaska.js"></script>
     <script type="text/javascript" src="assets/js/modal.js"></script>


### PR DESCRIPTION
This one is untested as I don't have the relevant DB schema at hand. But polishing it should be extremely simple and allow us to stay updated without manual polling.

There is one unresolved TODO in `toAtomDateConstruct` as I don't know what format the datetimes are kept in.